### PR TITLE
Sending FSN

### DIFF
--- a/tests/fsnCreate_and_Send_Asset.py
+++ b/tests/fsnCreate_and_Send_Asset.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+#
+# Demonstrate sending FSN tokens from one account to another
+#
+#
+from web3fsnpy import Web3Fsn
+import os
+import sys
+from eth_utils import (
+    to_hex,
+)
+
+
+testnet = "wss://testnetpublicgateway1.fusionnetwork.io:10001"
+mainnet = "wss://mainnetpublicgateway1.fusionnetwork.io:10001"
+
+web3fsn = Web3Fsn(Web3Fsn.WebsocketProvider(testnet))
+#
+#
+# Don't leave a private key hardcoded, so you could use an environmental variable to store it
+#
+try:  
+   private_key_sender = os.environ["FSN_PRIVATE_KEY"]
+except KeyError: 
+   print('Set environment variable FSN_PRIVATE_KEY to be private key of sending wallet (without 0x prefix)')
+   sys.exit(1)
+
+
+pub_key_sender = "0x7fbFa5679411a97bb2f73Dd5ad01Ca0822FaD9a6"
+pub_key_receiver = "0xaa8c70e134a5A88aBD0E390F2B479bc31C70Fee1"
+
+
+value = web3fsn.toWei(0.02,'ether')    # How much FSN are we sending?
+
+nonce = web3fsn.fsn.getTransactionCount(pub_key_sender)  # Get the nonce for the sending wallet
+
+# Construct the transaction
+
+transaction = {
+  "from":       pub_key_sender,
+  "name":       "Marcel coin",
+  "nonce":       nonce,
+  "symbol":     "MARCEL",
+  "decimals":   1,
+  "total":      0x200,
+  "canChange":  True,
+}
+
+# Fill in the defaults, including gas and gasLimit
+tx = web3fsn.fsn.fill_tx_defaults(transaction)
+
+# Sign the transaction
+
+signed_tx = web3fsn.fsn.account.sign_transaction(tx,private_key_sender)
+
+# Create the raw asset (i.e. signed)
+
+TxHash = web3fsn.fsn.createRawAsset(signed_tx.rawTransaction)
+#
+print('TxHash = ',to_hex(TxHash))
+#
+# We can optionally wait for the transaction to occur and block execution until it has done so, or times out after timeout seconds
+print('Waiting for transaction to go through...')
+web3fsn.fsn.waitForTransactionReceipt(TxHash, timeout=20)
+#
+#
+res = web3fsn.fsn.getTransaction(TxHash)
+#
+print(res)
+#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+transaction = {
+            "from"  : pub_key_sender,
+            "to"    : pub_key_receiver,
+            "nonce" : nonce,
+            "value" : value,
+}
+
+# Fill in the defaults, including gas and gasLimit
+
+tx = web3fsn.fsn.fill_tx_defaults(transaction)
+
+# Sign the transaction
+
+signed_tx = web3fsn.fsn.account.sign_transaction(tx,private_key_sender)
+
+# Send the raw transaction (i.e. signed)
+
+TxHash = web3fsn.fsn.sendRawTransaction(signed_tx.rawTransaction)
+#
+print('TxHash = ',to_hex(TxHash))
+#
+# We can optionally wait for the transaction to occur and block execution until it has done so, or times out after timeout seconds
+print('Waiting for transaction to go through...')
+web3fsn.fsn.waitForTransactionReceipt(TxHash, timeout=20)
+#
+#
+res = web3fsn.fsn.getTransaction(TxHash)
+#
+#print(res)
+#
+print('\nResults from the transaction :\n')
+print('Block number: ',res["blockNumber"])
+print('From        : ',res["from"])
+print('To          : ',res["to"])
+print('Value       : ',web3fsn.fromWei(res["value"],'ether'),' FSN')
+print('Gas price   : ',web3fsn.fromWei(res["gasPrice"],'gwei'),' gwei')
+

--- a/tests/fsnSendFSN.py
+++ b/tests/fsnSendFSN.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+#
+# Demonstrate sending FSN tokens from one account to another
+#
+#
+from web3fsnpy import Web3Fsn
+import os
+import sys
+from eth_utils import (
+    to_hex,
+)
+
+
+testnet = "wss://testnetpublicgateway1.fusionnetwork.io:10001"
+mainnet = "wss://mainnetpublicgateway1.fusionnetwork.io:10001"
+
+web3fsn = Web3Fsn(Web3Fsn.WebsocketProvider(testnet))
+#
+#
+# Don't leave a private key hardcoded, so you could use an environmental variable to store it
+#
+try:  
+   private_key_sender = os.environ["FSN_PRIVATE_KEY"]
+except KeyError: 
+   print('Set environment variable FSN_PRIVATE_KEY to be private key of sending wallet (without 0x prefix)')
+   sys.exit(1)
+
+
+pub_key_sender = "0x7fbFa5679411a97bb2f73Dd5ad01Ca0822FaD9a6"
+pub_key_receiver = "0xaa8c70e134a5A88aBD0E390F2B479bc31C70Fee1"
+
+
+value = web3fsn.toWei(0.02,'ether')    # How much FSN are we sending?
+
+nonce = web3fsn.fsn.getTransactionCount(pub_key_sender)  # Get the nonce for the sending wallet
+
+# Construct the transaction
+
+transaction = {
+            "from"  : pub_key_sender,
+            "to"    : pub_key_receiver,
+            "nonce" : nonce,
+            "value" : value,
+}
+
+# Fill in the defaults, including gas and gasLimit
+
+tx = web3fsn.fsn.fill_tx_defaults(transaction)
+
+# Sign the transaction
+
+signed_tx = web3fsn.fsn.account.sign_transaction(tx,private_key_sender)
+
+# Send the raw transaction (i.e. signed)
+
+TxHash = web3fsn.fsn.sendRawTransaction(signed_tx.rawTransaction)
+#
+print('TxHash = ',to_hex(TxHash))
+#
+# We can optionally wait for the transaction to occur and block execution until it has done so, or times out after timeout seconds
+print('Waiting for transaction to go through...')
+web3fsn.fsn.waitForTransactionReceipt(TxHash, timeout=20)
+#
+#
+res = web3fsn.fsn.getTransaction(TxHash)
+#
+#print(res)
+#
+print('\nResults from the transaction :\n')
+print('Block number: ',res["blockNumber"])
+print('From        : ',res["from"])
+print('To          : ',res["to"])
+print('Value       : ',web3fsn.fromWei(res["value"],'ether'),' FSN')
+print('Gas price   : ',web3fsn.fromWei(res["gasPrice"],'gwei'),' gwei')
+

--- a/web3fsnpy/_utils/encoding.py
+++ b/web3fsnpy/_utils/encoding.py
@@ -164,6 +164,7 @@ def to_bytes(primitive=None, hexstr=None, text=None):
         return decode_hex(hexstr)
     elif text is not None:
         return text.encode('utf-8')
+    
     raise TypeError("expected an int in first arg, or keyword of hexstr or text")
 
 

--- a/web3fsnpy/_utils/normalizers.py
+++ b/web3fsnpy/_utils/normalizers.py
@@ -23,17 +23,26 @@ from eth_utils.address import (
 from eth_utils.toolz import (
     curry,
 )
+from eth_utils.curried import (
+       hexstr_if_str,
+       text_if_str,
+       to_bytes,
+       to_hex,
+       to_text,
+)
+
 from hexbytes import (
     HexBytes,
 )
 
-from web3fsnpy._utils.encoding import (
-    hexstr_if_str,
-    text_if_str,
-    to_bytes,
-    to_hex,
-    to_text,
-)
+#from web3fsnpy._utils.encoding import (
+    #hexstr_if_str,
+    #text_if_str,
+    #to_bytes,
+    #to_hex,
+    #to_text,
+#)
+
 from web3fsnpy._utils.ens import (
     StaticENS,
     is_ens_name,
@@ -97,7 +106,6 @@ def parse_basic_type_str(old_normalizer):
 
         if not isinstance(abi_type, BasicType):
             return type_str, data
-
         return old_normalizer(abi_type, type_str, data)
 
     return new_normalizer
@@ -117,7 +125,7 @@ def abi_bytes_to_hex(abi_type, type_str, data):
     if len(bytes_data) > num_bytes:
         raise ValueError(
             "This value was expected to be at most %d bytes, but instead was %d: %r" % (
-                (num_bytes, len(bytes_data), data)
+                #(num_bytes, len(bytes_data), data)
             )
         )
 

--- a/web3fsnpy/_utils/transactions.py
+++ b/web3fsnpy/_utils/transactions.py
@@ -6,6 +6,11 @@ from eth_utils.toolz import (
     merge,
 )
 
+from eth_utils import (
+    to_hex,
+)
+
+
 from web3fsnpy._utils.threads import (
     Timeout,
 )
@@ -22,14 +27,22 @@ VALID_TRANSACTION_PARAMS = [
     'data',
     'nonce',
     'chainId',
+    'symbol',
+    'decimal',
+    'total',
+    'canChange',
+    'asset',
 ]
 
 TRANSACTION_DEFAULTS = {
     'value': 0,
     'data': b'',
-    'gas': lambda web3fsnpy, tx: web3fsnpy.fsn.estimateGas(tx),
-    'gasPrice': lambda web3fsnpy, tx: web3fsnpy.fsn.generateGasPrice(tx) or web3fsnpy.fsn.gasPrice,
-    'chainId': lambda web3fsnpy, tx: web3fsnpy.fsn.chainId,
+#    'gas': lambda web3fsnpy, tx: web3fsnpy.fsn.estimateGas(tx),
+#    'gasPrice': lambda web3fsnpy, tx: web3fsnpy.fsn.generateGasPrice(tx) or web3fsnpy.fsn.gasPrice,
+#    'nonce':     None,
+    'chainId':   None,
+    'gas':       300000,
+    'gasPrice':  2000000000,
 }
 
 

--- a/web3fsnpy/manager.py
+++ b/web3fsnpy/manager.py
@@ -92,7 +92,7 @@ class RequestManager:
         Make a synchronous request using the provider
         """
         response = self._make_request(method, params)
-
+        
         if "error" in response:
             raise ValueError(response["error"])
 

--- a/web3fsnpy/middleware/gas_price_strategy.py
+++ b/web3fsnpy/middleware/gas_price_strategy.py
@@ -7,6 +7,7 @@ def gas_price_strategy_middleware(make_request, web3fsnpy):
     """
     Includes a gas price using the gas price strategy
     """
+    
     def middleware(method, params):
         if method == 'eth_sendTransaction':
             transaction = params[0]

--- a/web3fsnpy/middleware/normalize_errors.py
+++ b/web3fsnpy/middleware/normalize_errors.py
@@ -13,7 +13,7 @@ def normalize_errors_middleware(make_request, web3fsnpy):
         # It used to return a result of None, so we simulate the old behavior.
 
         if method == 'eth_getTransactionReceipt' and 'error' in result:
-            is_geth = web3.clientVersion.startswith('Geth')
+            is_geth = web3fsnpy.clientVersion.startswith('Geth')
             if is_geth and result['error']['code'] == -32000:
                 return assoc(
                     dissoc(result, 'error'),

--- a/web3fsnpy/middleware/signing.py
+++ b/web3fsnpy/middleware/signing.py
@@ -6,6 +6,17 @@ import operator
 from eth_account import (
     Account,
 )
+
+from eth_account._utils.signing import (
+    hash_of_signed_transaction,
+    sign_message_hash,
+    sign_transaction_dict,
+    to_standard_signature_bytes,
+    to_standard_v,
+)
+
+
+
 from eth_account.signers.local import (
     LocalAccount,
 )
@@ -14,9 +25,14 @@ from eth_keys.datatypes import (
 )
 from eth_utils import (
     to_dict,
+    to_hex,
 )
 from eth_utils.toolz import (
     compose,
+)
+
+from hexbytes import (
+    HexBytes,
 )
 
 from web3fsnpy._utils.formatters import (
@@ -29,6 +45,9 @@ from web3fsnpy._utils.rpc_abi import (
 from web3fsnpy._utils.transactions import (
     fill_nonce,
     fill_transaction_defaults,
+)
+from web3fsnpy._utils.events import (
+    keccak,
 )
 
 from .abi import (
@@ -134,3 +153,5 @@ def construct_sign_and_send_raw_middleware(private_key_or_account):
         return middleware
 
     return sign_and_send_raw_middleware
+
+


### PR DESCRIPTION
Changes made allow FSN tokens to be sent between wallets. A test script is included, which also demonstrates some other functions like getTransaction and waitForTransactionReceipt.
Create and send assets does not yet work, but this is the focus now.